### PR TITLE
Roblox Group API integration

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-minimal


### PR DESCRIPTION
**Idea Proposal:**
To integrate Roblox's group API into the library to easily enable users to bind their Roblox group into Bloxlink.

**Proposed solution:**
Something like this:
```py
from Bloxlink import Bloxlink, Group

group = Group(group_id_here, any_necessary_api_keys)
bloxlink = Bloxlink("...", bind_group=group)

# Bind a Roblox group rank to a Discord role (as many as needed)
group.bind_role(discord_role, group_rank)
...

# Later on...
await bloxlink.update_user(user_id, from_group=True) # from_group kwarg will look into the Roblox group
```